### PR TITLE
Added the keep awake functionality

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -8,12 +8,14 @@ import {VibrationService} from "@/services/VibrationService";
 import {GestureHandlerRootView} from "react-native-gesture-handler";
 import {IExerciseService} from "@/services/IExerciseService";
 import {SqlExerciseService} from "@/services/SqlExerciseService";
+import {activateKeepAwakeAsync, deactivateKeepAwake} from "expo-keep-awake";
 
 export default function Index() {
   const [data, setData] = useState<ExerciseItemData[]>([]);
   const [nextExercise, setNextExercise] = useState(false);
   const [selectedExercise, setSelectedExercise] = useState<ExerciseItemData | undefined>();
   const [timerState, setTimerState] = useState<TimerState>(TimerState.STOPPED);
+  const [keepAwake, setKeepAwake] = useState<boolean>(false);
   const exerciseService = useRef<IExerciseService>(new SqlExerciseService());
 
   useEffect(() => {
@@ -24,7 +26,15 @@ export default function Index() {
 
   useEffect(() => {
     if (timerState === TimerState.RUNNING) VibrationService.startTraining();
+
+    if (timerState === TimerState.RUNNING) setKeepAwake(true);
+    else setKeepAwake(false);
   }, [timerState])
+
+  useEffect(() => {
+    if (!keepAwake) deactivateKeepAwake().then();
+    else activateKeepAwakeAsync().then();
+  }, [keepAwake]);
 
   const onNextExercise = () => {
     setNextExercise(true);

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo-font": "~13.3.1",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.2.0",
+        "expo-keep-awake": "~14.1.4",
         "expo-linking": "~7.1.5",
         "expo-notifications": "~0.31.3",
         "expo-router": "~5.0.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "build:android": "eas build --platform android --profile preview"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -41,7 +42,8 @@
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "expo-sqlite": "~15.2.12"
+    "expo-sqlite": "~15.2.12",
+    "expo-keep-awake": "~14.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
The app now uses the expo keep-awake package to keep the screen (and thus the app) awake so you won't have to touch the screen during exercise to keep the app running.